### PR TITLE
3 no abstraction for gpio ports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,18 +8,6 @@ use defmt_rtt as _;
 use panic_probe as _;
 use stm32f4xx_hal::{self as _, gpio::alt::SerialFlowControl};
 
-fn wait() -> () {
-    const WAIT_TIME: u32 = 100000; // temporarily make it faster ?
-    for _ in 0..WAIT_TIME {}
-}
-
-fn blink_led(reg: GpioRegister, led_pin: &GpioPin) -> () {
-    led_pin.set(reg, 5);
-    wait();
-    led_pin.clear(reg, 5);
-    wait();
-}
-
 #[derive(Copy, Clone)]
 enum GpioPort {
     A,
@@ -100,7 +88,7 @@ struct GpioPin {
 
 impl GpioPin {
     fn new(port: GpioPort, pin: u8) -> Self {
-        // GpioPin {
+        GpioPin {
             port: port,
             pin: pin,
         }
@@ -155,54 +143,11 @@ fn main() -> ! {
     pc13.set(GpioRegister::PUPDR, 26);
     loop {
         if pc13.read(GpioRegister::IDR, 13) {
-            pa5.clear(GpioRegister::ODR, 5);
+            // if button not pressed
+            pa5.clear(GpioRegister::ODR, 5); // LED off
         } else {
-            pa5.set(GpioRegister::ODR, 5);
+            // button is pressed
+            pa5.set(GpioRegister::ODR, 5); // LED on
         }
-        //blink_led(GpioRegister::ODR, &pa5);
     }
 }
-
-/*
-/
-
-#include <stdint.h>
-
-#if !defined(__SOFT_FP__) && defined(__ARM_FP)
-  #warning "FPU is not initialized, but the project is compiling for an FPU. Please initialize the FPU before use."
-#endif
-
-void wait() {
-    for (volatile int i = 0; i < 1000000; i++) {
-        ;
-    }
-}
-
-int main(void)
-{
-    /* Loop forever */
-
-    // GPIOA = 0x4002 0000 - 0x4002 03FF
-
-    volatile uint32_t* RCC_AHB1ENR = (uint32_t*)0x40023830; // base address + 0x30 offset = 0x40023800 + 0x30
-
-    volatile uint32_t* GPIOA_MODER = (uint32_t*)0x40020000;
-
-    volatile uint32_t* GPIOA_ODR = (uint32_t*)0x40020014; // base address + offset
-
-    *RCC_AHB1ENR |= 1 <<0; // enable clock
-    *GPIOA_MODER &= ~(1 << 11); // clear bit 11 on MODER5 to 0
-    *GPIOA_MODER |= 1 << 10; // set bit 10 to 1
-
-    int true = 1;
-    while (true) {
-        *GPIOA_ODR |= 1 << 5;
-        wait();
-        *GPIOA_ODR &= ~(1 << 5);
-        wait();
-    }
-
-    for(;;);
-}
-
- */

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,72 @@ impl GpioRegister {
     }
 }
 
+enum ModerState {
+    Input,
+    Output,
+    Alternate,
+    Analog,
+}
+
+impl ModerState {
+    fn bit_pattern(&self) -> u8 {
+        match self {
+            ModerState::Input => 0b00,
+            ModerState::Output => 0b01,
+            ModerState::Alternate => 0b10,
+            ModerState::Analog => 0b11,
+        }
+    }
+}
+
+enum OTyperState {
+    PushPull,
+    OpenDrain,
+}
+
+impl OTyperState {
+    fn bit_pattern(&self) -> u8 {
+        match self {
+            OTyperState::PushPull => 0b00,
+            OTyperState::OpenDrain => 0b01,
+        }
+    }
+}
+
+enum OSpeedrState {
+    Low,
+    Medium,
+    Fast,
+    High,
+}
+
+impl OSpeedrState {
+    fn bit_pattern(&self) -> u8 {
+        match self {
+            OSpeedrState::Low => 0b00,
+            OSpeedrState::Medium => 0b01,
+            OSpeedrState::Fast => 0b10,
+            OSpeedrState::High => 0b11,
+        }
+    }
+}
+
+enum PupdrState {
+    NoPullUpPullDown,
+    PullUp,
+    PullDown,
+}
+
+impl PupdrState {
+    fn bit_pattern(&self) -> u8 {
+        match self {
+            PupdrState::NoPullUpPullDown => 0b00,
+            PupdrState::PullUp => 0b01,
+            PupdrState::PullDown => 0b10,
+        }
+    }
+}
+
 struct GpioPin {
     port: GpioPort,
     pin: u8,
@@ -122,6 +188,34 @@ impl GpioPin {
             val & (1 << bit) != 0
         }
     }
+
+    fn clear_reg_bits(&self, reg: GpioRegister) -> () {
+        let bits = self.pin * reg.bits_per_pin();
+        let mask: u8;
+        match reg.bits_per_pin() {
+            1 => mask = 0b01,
+            2 => mask = 0b11,
+            _ => unreachable!(), // impossible given our register definitions
+        };
+
+        let address = reg.offset() + self.port.address();
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            ptr.write_volatile(val & !((mask as u32) << (bits as u32))); // clear bits we want to set the mode of
+        }
+    }
+
+    fn set_mode(&self, mode: ModerState) -> () {
+        let bits = self.pin * GpioRegister::MODER.bits_per_pin(); // starting bit
+        let address = GpioRegister::MODER.offset() + self.port.address();
+        self.clear_reg_bits(GpioRegister::MODER); // ensure the bits are ready to set a mode
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            ptr.write_volatile(val | ((mode.bit_pattern() as u32) << (bits as u32))) // set the desired mode
+        }
+    }
 }
 
 #[cortex_m_rt::entry]
@@ -134,12 +228,13 @@ fn main() -> ! {
     }
 
     let pa5 = GpioPin::new(GpioPort::A, 5);
-    pa5.clear(GpioRegister::MODER, 11);
-    pa5.set(GpioRegister::MODER, 10);
-
+    // pa5.clear(GpioRegister::MODER, 11);
+    // pa5.set(GpioRegister::MODER, 10);
+    pa5.set_mode(ModerState::Output);
     let pc13 = GpioPin::new(GpioPort::C, 13);
-    pc13.clear(GpioRegister::MODER, 27);
-    pc13.clear(GpioRegister::MODER, 26);
+    // pc13.clear(GpioRegister::MODER, 27);
+    // pc13.clear(GpioRegister::MODER, 26);
+    pc13.set_mode(ModerState::Input);
     pc13.set(GpioRegister::PUPDR, 26);
     loop {
         if pc13.read(GpioRegister::IDR, 13) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,31 +19,90 @@ fn blink_led(gpio_odr: *mut u32) -> () {
     }
 }
 
+enum GpioPort {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+}
+
+enum GpioRegister {
+    MODER,
+    OTYPER,
+    OSPEEDR,
+    PUPDR,
+    IDR,
+    ODR,
+    BSRR,
+    LCKR,
+    AFLR,
+    AFHR,
+}
+
+impl GpioRegister {
+    fn offset(&self) -> u32 {
+        match self {
+            GpioRegister::MODER => 0x00,
+            GpioRegister::OTYPER => 0x04,
+            GpioRegister::OSPEEDR => 0x08,
+            GpioRegister::PUPDR => 0x0C,
+            GpioRegister::IDR => 0x10,
+            GpioRegister::ODR => 0x14,
+            GpioRegister::BSRR => 0x18,
+            GpioRegister::LCKR => 0x1C,
+            GpioRegister::AFLR => 0x20,
+            GpioRegister::AFHR => 0x24,
+        }
+    }
+}
+
+struct GpioPin {
+    register: GpioRegister,
+    pin: u8,
+    port: GpioPort,
+    address: u32,
+}
+
 #[cortex_m_rt::entry]
 fn main() -> ! {
     defmt::info!("hello from miracle");
     let rcc_ahb1enr = 0x40023830 as *mut u32;
+    let gpio_clock_control = Rcc::ahb1ener::new();
+    let gpio_port_a = GpioPort::A;
+    gpio_clock_control.enable(gpio_port_a);
+    
     let gpio_moder = 0x40020000 as *mut u32;
-    let gpio_odr = 0x40020014  as *mut u32;
+    let gpio_moder = GpioRegister(port, pin, register: GpioRegister::MODER);
+    gpio_moder.clear(bit: 11);
+    gpio_moder.set(bit: 10);
+    let led_control = GpioRegister(gpio_port_a, 13, register: GpioRegister::ODR);
+    led_control.set(bit: 5);
+    led_control.clear(bit: 5); // led on / off
+    let gpio_odr = 0x40020014 as *mut u32;
     let gpioc_moder = 0x40020800 as *mut u32; // PC13 - GPIO_C
     let gpioc_pupdr = 0x4002080C as *mut u32; // PC13 - GPIO_C PUPDR register offset 0x0C
     let gpioc_idr = 0x40020810 as *mut u32; // PC13 GPIO_C + IDR OFFSET 0x10
 
-   unsafe { // enable clock and setup
-       *rcc_ahb1enr |= 1 << 0; // enable clock on gpio port A
-       *rcc_ahb1enr |= 1 << 2; // enable clock on gpio port C
-       *gpio_moder &= !(1 << 11);
-       *gpio_moder |= 1 << 10;
-       *gpioc_moder &= !(1 << 27); // MODER 13 set bit 27 to 0
-       *gpioc_moder &= !(1 << 26); // MODER 13 set bit 27 to 0
-       *gpioc_pupdr |= 1 << 26; // set bit 26 to 1 - sets to PULL UP - if button is pressed this is pulled to 0
-       loop {
-           if ((*gpioc_idr & (1 << 13)) != 0) { // IDR pin state (pressed/not pressed),
-               // need to check the IDR register for actual IO state. ^
-                 *gpio_odr &= !( 1 << 5); // turn off LD2 bc pin state is 1, button not pressed
-            }
-            else {
-                 *gpio_odr |= 1 << 5; // turn on LD2 bc pin state is 0, button is pressed
+    unsafe {
+        // enable clock and setup
+        *rcc_ahb1enr |= 1 << 0; // enable clock on gpio port A
+        *rcc_ahb1enr |= 1 << 2; // enable clock on gpio port C
+        *gpio_moder &= !(1 << 11);
+        *gpio_moder |= 1 << 10;
+        *gpioc_moder &= !(1 << 27); // MODER 13 set bit 27 to 0
+        *gpioc_moder &= !(1 << 26); // MODER 13 set bit 27 to 0
+        *gpioc_pupdr |= 1 << 26; // set bit 26 to 1 - sets to PULL UP - if button is pressed this is pulled to 0
+        loop {
+            if ((*gpioc_idr & (1 << 13)) != 0) {
+                // IDR pin state (pressed/not pressed),
+                // need to check the IDR register for actual IO state. ^
+                *gpio_odr &= !(1 << 5); // turn off LD2 bc pin state is 1, button not pressed
+            } else {
+                *gpio_odr |= 1 << 5; // turn on LD2 bc pin state is 0, button is pressed
             }
         }
     }
@@ -59,36 +118,36 @@ fn main() -> ! {
 #endif
 
 void wait() {
-	for (volatile int i = 0; i < 1000000; i++) {
-		;
-	}
+    for (volatile int i = 0; i < 1000000; i++) {
+        ;
+    }
 }
 
 int main(void)
 {
     /* Loop forever */
 
-	// GPIOA = 0x4002 0000 - 0x4002 03FF
+    // GPIOA = 0x4002 0000 - 0x4002 03FF
 
-	volatile uint32_t* RCC_AHB1ENR = (uint32_t*)0x40023830; // base address + 0x30 offset = 0x40023800 + 0x30
+    volatile uint32_t* RCC_AHB1ENR = (uint32_t*)0x40023830; // base address + 0x30 offset = 0x40023800 + 0x30
 
-	volatile uint32_t* GPIOA_MODER = (uint32_t*)0x40020000;
+    volatile uint32_t* GPIOA_MODER = (uint32_t*)0x40020000;
 
-	volatile uint32_t* GPIOA_ODR = (uint32_t*)0x40020014; // base address + offset
+    volatile uint32_t* GPIOA_ODR = (uint32_t*)0x40020014; // base address + offset
 
-	*RCC_AHB1ENR |= 1 <<0; // enable clock
-	*GPIOA_MODER &= ~(1 << 11); // clear bit 11 on MODER5 to 0
-	*GPIOA_MODER |= 1 << 10; // set bit 10 to 1
+    *RCC_AHB1ENR |= 1 <<0; // enable clock
+    *GPIOA_MODER &= ~(1 << 11); // clear bit 11 on MODER5 to 0
+    *GPIOA_MODER |= 1 << 10; // set bit 10 to 1
 
-	int true = 1;
-	while (true) {
-		*GPIOA_ODR |= 1 << 5;
-		wait();
-		*GPIOA_ODR &= ~(1 << 5);
-		wait();
-	}
+    int true = 1;
+    while (true) {
+        *GPIOA_ODR |= 1 << 5;
+        wait();
+        *GPIOA_ODR &= ~(1 << 5);
+        wait();
+    }
 
-	for(;;);
+    for(;;);
 }
 
  */

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,21 @@ impl GpioRegister {
             GpioRegister::AFHR => 0x24,
         }
     }
+
+    fn bits_per_pin(&self) -> u8 {
+        match self {
+            GpioRegister::MODER => 2,
+            GpioRegister::OTYPER => 1,
+            GpioRegister::OSPEEDR => 2,
+            GpioRegister::PUPDR => 2,
+            GpioRegister::IDR => 1,
+            GpioRegister::ODR => 1,
+            GpioRegister::BSRR => 2,
+            GpioRegister::LCKR => 2,
+            GpioRegister::AFLR => 2,
+            GpioRegister::AFHR => 2,
+        }
+     }
 }
 
 struct GpioPin {

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,15 @@ impl GpioPin {
             ptr.write_volatile(val & !(1 << bit));
         }
     }
+
+    fn read(&self, register: GpioRegister, bit: u8) -> bool {
+        let address = register.offset() + self.port.address();
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            val & (1 << bit) != 0
+        }
+    }
 }
 
 #[cortex_m_rt::entry]
@@ -139,33 +148,18 @@ fn main() -> ! {
     let pa5 = GpioPin::new(GpioPort::A, 21);
     pa5.clear(GpioRegister::MODER, 11);
     pa5.set(GpioRegister::MODER, 10);
-    loop {
-        blink_led(GpioRegister::ODR, &pa5);
-    }
-    let gpio_moder = 0x40020000 as *mut u32;
-    let gpio_odr = 0x40020014 as *mut u32;
-    let gpioc_moder = 0x40020800 as *mut u32; // PC13 - GPIO_C
-    let gpioc_pupdr = 0x4002080C as *mut u32; // PC13 - GPIO_C PUPDR register offset 0x0C
-    let gpioc_idr = 0x40020810 as *mut u32; // PC13 GPIO_C + IDR OFFSET 0x10
 
-    unsafe {
-        // enable clock and setup
-        *rcc_ahb1enr |= 1 << 0; // enable clock on gpio port A
-        *rcc_ahb1enr |= 1 << 2; // enable clock on gpio port C
-        *gpio_moder &= !(1 << 11);
-        *gpio_moder |= 1 << 10;
-        *gpioc_moder &= !(1 << 27); // MODER 13 set bit 27 to 0
-        *gpioc_moder &= !(1 << 26); // MODER 13 set bit 27 to 0
-        *gpioc_pupdr |= 1 << 26; // set bit 26 to 1 - sets to PULL UP - if button is pressed this is pulled to 0
-        loop {
-            if ((*gpioc_idr & (1 << 13)) != 0) {
-                // IDR pin state (pressed/not pressed),
-                // need to check the IDR register for actual IO state. ^
-                *gpio_odr &= !(1 << 5); // turn off LD2 bc pin state is 1, button not pressed
-            } else {
-                *gpio_odr |= 1 << 5; // turn on LD2 bc pin state is 0, button is pressed
-            }
+    let pc13 = GpioPin::new(GpioPort::C, 2);
+    pc13.clear(GpioRegister::MODER, 27);
+    pc13.clear(GpioRegister::MODER, 26);
+    pc13.set(GpioRegister::PUPDR, 26);
+    loop {
+        if pc13.read(GpioRegister::IDR, 13) {
+            pa5.clear(GpioRegister::ODR, 5);
+        } else {
+            pa5.set(GpioRegister::ODR, 5);
         }
+        //blink_led(GpioRegister::ODR, &pa5);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ struct GpioPin {
 
 impl GpioPin {
     fn new(port: GpioPort, pin: u8) -> Self {
-        GpioPin {
+        // GpioPin {
             port: port,
             pin: pin,
         }
@@ -145,11 +145,11 @@ fn main() -> ! {
         *rcc_ahb1enr |= 1 << 2; // enable clock on gpio port C
     }
 
-    let pa5 = GpioPin::new(GpioPort::A, 21);
+    let pa5 = GpioPin::new(GpioPort::A, 5);
     pa5.clear(GpioRegister::MODER, 11);
     pa5.set(GpioRegister::MODER, 10);
 
-    let pc13 = GpioPin::new(GpioPort::C, 2);
+    let pc13 = GpioPin::new(GpioPort::C, 13);
     pc13.clear(GpioRegister::MODER, 27);
     pc13.clear(GpioRegister::MODER, 26);
     pc13.set(GpioRegister::PUPDR, 26);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 #![no_std]
 #![no_main]
 
+use core::ptr::read_volatile;
+
+use cortex_m::prelude::_embedded_hal_timer_CountDown;
 use defmt_rtt as _;
 use panic_probe as _;
 use stm32f4xx_hal::{self as _, gpio::alt::SerialFlowControl};
@@ -10,15 +13,14 @@ fn wait() -> () {
     for _ in 0..WAIT_TIME {}
 }
 
-fn blink_led(gpio_odr: *mut u32) -> () {
-    unsafe {
-        *gpio_odr |= 1 << 5;
-        wait();
-        *gpio_odr &= !(1 << 5);
-        wait();
-    }
+fn blink_led(reg: GpioRegister, led_pin: &GpioPin) -> () {
+    led_pin.set(reg, 5);
+    wait();
+    led_pin.clear(reg, 5);
+    wait();
 }
 
+#[derive(Copy, Clone)]
 enum GpioPort {
     A,
     B,
@@ -45,6 +47,7 @@ impl GpioPort {
     }
 }
 
+#[derive(Copy, Clone)]
 enum GpioRegister {
     MODER,
     OTYPER,
@@ -91,16 +94,54 @@ impl GpioRegister {
 }
 
 struct GpioPin {
-    register: GpioRegister,
-    pin: u8,
     port: GpioPort,
-    address: u32,
+    pin: u8,
+}
+
+impl GpioPin {
+    fn new(port: GpioPort, pin: u8) -> Self {
+        GpioPin {
+            port: port,
+            pin: pin,
+        }
+    }
+
+    fn set(&self, register: GpioRegister, bit: u8) -> () {
+        // set bit to 1
+        let address = register.offset() + self.port.address();
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            ptr.write_volatile(val | (1 << bit));
+        }
+    }
+
+    fn clear(&self, register: GpioRegister, bit: u8) -> () {
+        // set bit to 0
+        let address = register.offset() + self.port.address();
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            ptr.write_volatile(val & !(1 << bit));
+        }
+    }
 }
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
     defmt::info!("hello from miracle");
     let rcc_ahb1enr = 0x40023830 as *mut u32;
+    unsafe {
+        *rcc_ahb1enr |= 1 << 0; // enable clock on gpio port A
+        *rcc_ahb1enr |= 1 << 2; // enable clock on gpio port C
+    }
+
+    let pa5 = GpioPin::new(GpioPort::A, 21);
+    pa5.clear(GpioRegister::MODER, 11);
+    pa5.set(GpioRegister::MODER, 10);
+    loop {
+        blink_led(GpioRegister::ODR, &pa5);
+    }
     let gpio_moder = 0x40020000 as *mut u32;
     let gpio_odr = 0x40020014 as *mut u32;
     let gpioc_moder = 0x40020800 as *mut u32; // PC13 - GPIO_C

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 use defmt_rtt as _;
 use panic_probe as _;
-use stm32f4xx_hal as _;
+use stm32f4xx_hal::{self as _, gpio::alt::SerialFlowControl};
 
 fn wait() -> () {
     const WAIT_TIME: u32 = 100000; // temporarily make it faster ?
@@ -28,6 +28,21 @@ enum GpioPort {
     F,
     G,
     H,
+}
+
+impl GpioPort {
+    fn address(&self) -> u32 {
+        match self {
+            GpioPort::A => 0x40020000,
+            GpioPort::B => 0x40020400,
+            GpioPort::C => 0x40020800,
+            GpioPort::D => 0x40020C00,
+            GpioPort::E => 0x40021000,
+            GpioPort::F => 0x40021400,
+            GpioPort::G => 0x40021800,
+            GpioPort::H => 0x40021C00,
+        }
+    }
 }
 
 enum GpioRegister {
@@ -72,7 +87,7 @@ impl GpioRegister {
             GpioRegister::AFLR => 2,
             GpioRegister::AFHR => 2,
         }
-     }
+    }
 }
 
 struct GpioPin {
@@ -86,17 +101,7 @@ struct GpioPin {
 fn main() -> ! {
     defmt::info!("hello from miracle");
     let rcc_ahb1enr = 0x40023830 as *mut u32;
-    let gpio_clock_control = Rcc::ahb1ener::new();
-    let gpio_port_a = GpioPort::A;
-    gpio_clock_control.enable(gpio_port_a);
-    
     let gpio_moder = 0x40020000 as *mut u32;
-    let gpio_moder = GpioRegister(port, pin, register: GpioRegister::MODER);
-    gpio_moder.clear(bit: 11);
-    gpio_moder.set(bit: 10);
-    let led_control = GpioRegister(gpio_port_a, 13, register: GpioRegister::ODR);
-    led_control.set(bit: 5);
-    led_control.clear(bit: 5); // led on / off
     let gpio_odr = 0x40020014 as *mut u32;
     let gpioc_moder = 0x40020800 as *mut u32; // PC13 - GPIO_C
     let gpioc_pupdr = 0x4002080C as *mut u32; // PC13 - GPIO_C PUPDR register offset 0x0C

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,9 +160,20 @@ impl GpioPin {
         }
     }
 
-    fn set(&self, register: GpioRegister, bit: u8) -> () {
+    fn bit_offset(&self, reg: GpioRegister) -> u8 {
+        let bit = self.pin * reg.bits_per_pin();
+        return bit;
+    }
+
+    fn address_offset(&self, reg: GpioRegister) -> u32 {
+        let address = self.port.address() + reg.offset();
+        return address;
+    }
+
+    fn set(&self, register: GpioRegister) -> () {
         // set bit to 1
-        let address = register.offset() + self.port.address();
+        let bit = self.bit_offset(register);
+        let address = self.address_offset(register);
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -170,9 +181,10 @@ impl GpioPin {
         }
     }
 
-    fn clear(&self, register: GpioRegister, bit: u8) -> () {
+    fn clear(&self, register: GpioRegister) -> () {
         // set bit to 0
-        let address = register.offset() + self.port.address();
+        let bit = self.bit_offset(register);
+        let address = self.address_offset(register);
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -180,8 +192,9 @@ impl GpioPin {
         }
     }
 
-    fn read(&self, register: GpioRegister, bit: u8) -> bool {
-        let address = register.offset() + self.port.address();
+    fn read(&self, register: GpioRegister) -> bool {
+        let bit = self.bit_offset(register);
+        let address = self.address_offset(register);
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -190,7 +203,7 @@ impl GpioPin {
     }
 
     fn clear_reg_bits(&self, reg: GpioRegister) -> () {
-        let bits = self.pin * reg.bits_per_pin();
+        let bits = self.bit_offset(reg);
         let mask: u8;
         match reg.bits_per_pin() {
             1 => mask = 0b01,
@@ -198,7 +211,7 @@ impl GpioPin {
             _ => unreachable!(), // impossible given our register definitions
         };
 
-        let address = reg.offset() + self.port.address();
+        let address = self.address_offset(reg);
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -207,9 +220,10 @@ impl GpioPin {
     }
 
     fn set_mode(&self, mode: ModerState) -> () {
-        let bits = self.pin * GpioRegister::MODER.bits_per_pin(); // starting bit
-        let address = GpioRegister::MODER.offset() + self.port.address();
-        self.clear_reg_bits(GpioRegister::MODER); // ensure the bits are ready to set a mode
+        let reg = GpioRegister::MODER;
+        let bits = self.bit_offset(reg); // starting bit
+        let address = self.address_offset(reg);
+        self.clear_reg_bits(reg); // ensure the bits are ready to set a mode
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -218,9 +232,10 @@ impl GpioPin {
     }
 
     fn set_speed(&self, speed: OSpeedrState) -> () {
-        let bits = self.pin * GpioRegister::OSPEEDR.bits_per_pin();
-        let address = GpioRegister::OSPEEDR.offset() + self.port.address();
-        self.clear_reg_bits(GpioRegister::OSPEEDR);
+        let reg = GpioRegister::OSPEEDR;
+        let bits = self.bit_offset(reg);
+        let address = self.address_offset(reg);
+        self.clear_reg_bits(reg);
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -229,9 +244,10 @@ impl GpioPin {
     }
 
     fn set_output_type(&self, output_type: OTyperState) -> () {
-        let bits = self.pin * GpioRegister::OTYPER.bits_per_pin();
-        let address = GpioRegister::OTYPER.offset() + self.port.address();
-        self.clear_reg_bits(GpioRegister::OTYPER);
+        let reg = GpioRegister::OTYPER;
+        let bits = self.bit_offset(reg);
+        let address = self.address_offset(reg);
+        self.clear_reg_bits(reg);
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -240,9 +256,10 @@ impl GpioPin {
     }
 
     fn set_pull(&self, pull: PupdrState) -> () {
-        let bits = self.pin * GpioRegister::PUPDR.bits_per_pin();
-        let address = GpioRegister::PUPDR.offset() + self.port.address();
-        self.clear_reg_bits(GpioRegister::PUPDR);
+        let reg = GpioRegister::PUPDR;
+        let bits = self.bit_offset(reg);
+        let address = self.address_offset(reg);
+        self.clear_reg_bits(reg);
         unsafe {
             let ptr = address as *mut u32;
             let val = ptr.read_volatile();
@@ -261,22 +278,18 @@ fn main() -> ! {
     }
 
     let pa5 = GpioPin::new(GpioPort::A, 5);
-    // pa5.clear(GpioRegister::MODER, 11);
-    // pa5.set(GpioRegister::MODER, 10);
-    pa5.set_mode(ModerState::Output);
     let pc13 = GpioPin::new(GpioPort::C, 13);
-    // pc13.clear(GpioRegister::MODER, 27);
-    // pc13.clear(GpioRegister::MODER, 26);
+    pa5.set_mode(ModerState::Output);
     pc13.set_mode(ModerState::Input);
     pc13.set_pull(PupdrState::PullUp);
-    // pc13.set(GpioRegister::PUPDR, 26);
+
     loop {
-        if pc13.read(GpioRegister::IDR, 13) {
+        if pc13.read(GpioRegister::IDR) {
             // if button not pressed
-            pa5.clear(GpioRegister::ODR, 5); // LED off
+            pa5.clear(GpioRegister::ODR); // LED off
         } else {
             // button is pressed
-            pa5.set(GpioRegister::ODR, 5); // LED on
+            pa5.set(GpioRegister::ODR); // LED on
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,6 +216,39 @@ impl GpioPin {
             ptr.write_volatile(val | ((mode.bit_pattern() as u32) << (bits as u32))) // set the desired mode
         }
     }
+
+    fn set_speed(&self, speed: OSpeedrState) -> () {
+        let bits = self.pin * GpioRegister::OSPEEDR.bits_per_pin();
+        let address = GpioRegister::OSPEEDR.offset() + self.port.address();
+        self.clear_reg_bits(GpioRegister::OSPEEDR);
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            ptr.write_volatile(val | ((speed.bit_pattern() as u32) << (bits as u32)));
+        }
+    }
+
+    fn set_output_type(&self, output_type: OTyperState) -> () {
+        let bits = self.pin * GpioRegister::OTYPER.bits_per_pin();
+        let address = GpioRegister::OTYPER.offset() + self.port.address();
+        self.clear_reg_bits(GpioRegister::OTYPER);
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            ptr.write_volatile(val | ((output_type.bit_pattern() as u32) << (bits as u32)));
+        }
+    }
+
+    fn set_pull(&self, pull: PupdrState) -> () {
+        let bits = self.pin * GpioRegister::PUPDR.bits_per_pin();
+        let address = GpioRegister::PUPDR.offset() + self.port.address();
+        self.clear_reg_bits(GpioRegister::PUPDR);
+        unsafe {
+            let ptr = address as *mut u32;
+            let val = ptr.read_volatile();
+            ptr.write_volatile(val | ((pull.bit_pattern() as u32) << (bits as u32)));
+        }
+    }
 }
 
 #[cortex_m_rt::entry]
@@ -235,7 +268,8 @@ fn main() -> ! {
     // pc13.clear(GpioRegister::MODER, 27);
     // pc13.clear(GpioRegister::MODER, 26);
     pc13.set_mode(ModerState::Input);
-    pc13.set(GpioRegister::PUPDR, 26);
+    pc13.set_pull(PupdrState::PullUp);
+    // pc13.set(GpioRegister::PUPDR, 26);
     loop {
         if pc13.read(GpioRegister::IDR, 13) {
             // if button not pressed


### PR DESCRIPTION
- **GpioPort enum + GpioRegister enum created, with an impl to return the GpioRegister offset.**
- **added GpioReset.bits_per_pin()**
- **added address() to GpioPort enum**
- **implementing blinking LED using GpioPin and GpioRegister**
- **implemented LED toggle with button 1, same as main but using GpioPin and GpioRegister abstraction**
- **corrected pc13 and pa5 pin number**
- **removed blink_led() and wait(). bad abstractions and messy. also removed commented reference C code.**
- **added enums and state to stateful registers. calculating bit positions based on pin number and register bits. set_mode() to handle MODER register, and clear_reg_bits() helper fn to ensure consistent state when setting registers**
- **added remaining stateful set_ functions to GpioPin**
- **added bit and address offset helpers, cleaned up bit operations to use these.**
